### PR TITLE
Fix Dockerfile to prevent 'Version for nodejs not found'

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
     curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \
     echo 'deb https://deb.nodesource.com/node_0.12 trusty main' > /etc/apt/sources.list.d/nodesource.list && \
     apt-get update -q && \
-    apt-get -y install build-essential gettext git inotify-tools nodejs=0.12.9-1nodesource1~trusty1 postgresql-client && \
+    apt-get -y install build-essential gettext git inotify-tools nodejs=0.12.10-1nodesource1~trusty1 postgresql-client && \
     apt-get clean -y && \
     rm -rf /var/cache/apt/*
 


### PR DESCRIPTION
0.12.9 can't get pulled for some reason, 0.12.10 is a new one.

http://www.ubuntuupdates.org/ppa/nodejs_v012?dist=trusty
